### PR TITLE
add FloodAlertsLayer; small aeris layer refactor

### DIFF
--- a/web-viewer/src/reducers/featureLayers.es
+++ b/web-viewer/src/reducers/featureLayers.es
@@ -19,11 +19,19 @@ const initialState = {
       'active': false,
     },
     {
-      'id': 'weather-radar',
+      'id': 'animated-weather',
       'text': 'Weather Radar',
-      'type': 'aeris-radar',
+      'type': 'animated-weather',
       'active': false,
     },
+    //TODO: Removed until Aeris subscription has been purchased
+    // since their advisory layers don't work under the dev plan
+    // {
+    //   'id': 'flood-alerts',
+    //   'text': 'Flood Alerts',
+    //   'type': 'flood-alerts',
+    //   'active': false,
+    // },
   ],
 }
 

--- a/web-viewer/src/util/AnimatedWeatherLayer.es
+++ b/web-viewer/src/util/AnimatedWeatherLayer.es
@@ -4,7 +4,7 @@ import R from 'ramda'
 import keys from '../keys'
 import Layer from './Layer'
 
-export class AnimatedWeatherLayer extends Layer {
+export default class AnimatedWeatherLayer extends Layer {
   constructor() {
     super()
 

--- a/web-viewer/src/util/FloodAlertsLayer.es
+++ b/web-viewer/src/util/FloodAlertsLayer.es
@@ -1,0 +1,35 @@
+import keys from '../keys'
+import Layer from './Layer'
+
+//TODO: advisory map layers requires an Aeris subscription - they are not available under the development plan
+export default class FloodAlertsLayer extends Layer {
+  constructor() {
+    super()
+    this.refreshIntervalId = null
+    // this.refreshTimeMs = 360000 //6 minutes
+    this.refreshTimeMs = 3000 //6 minutes
+
+    const url = `https://tile{s}.aerisapi.com/${keys.aerisApiId}_${keys.aerisApiSecret}/alerts-flood/{z}/{x}/{y}/0.png`
+    this.layer = L.tileLayer(url, {
+      subdomains: '1234',
+      opacity: 0.6,
+      attribution: 'Aeris Weather'
+    })
+  }
+
+  addTo(map) {
+    this.layer.addTo(map)
+    this.refreshIntervalId = setInterval(() => this.layer.redraw(), this.refreshTimeMs)
+  }
+
+  removeFrom(map) {
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId)
+      this.refreshIntervalId = null
+    }
+
+    if (map.hasLayer(this.layer)) {
+      map.removeLayer(this.layer)
+    }
+  }
+}

--- a/web-viewer/src/util/Layer.es
+++ b/web-viewer/src/util/Layer.es
@@ -2,4 +2,12 @@ export default class Layer {
   constructor() {
     this.status = 'pending'
   }
+
+  addTo() {
+    throw new Error('addTo is undefined')
+  }
+
+  removeFrom() {
+    throw new Error('removeFrom is undefined')
+  }
 }

--- a/web-viewer/src/util/LayerStore.es
+++ b/web-viewer/src/util/LayerStore.es
@@ -1,5 +1,6 @@
 import * as cartodb from './cartodb'
-import * as aeris from './aeris'
+import AnimatedWeatherLayer from './AnimatedWeatherLayer'
+import FloodAlertsLayer from './FloodAlertsLayer'
 
 
 export default class LayerStore {
@@ -20,8 +21,11 @@ export default class LayerStore {
       case 'cartodb':
         this.store[id] = new cartodb.CartoDBLayer(options)
         break
-      case 'aeris-radar':
-        this.store[id] = new aeris.AnimatedWeatherLayer(options)
+      case 'animated-weather':
+        this.store[id] = new AnimatedWeatherLayer(options)
+        break
+      case 'flood-alerts':
+        this.store[id] = new FloodAlertsLayer(options)
         break
       default:
         null


### PR DESCRIPTION
Need to wait for an Aeris subscription (#31) for the FloodAlertsLayer to actually work. It's a simple layer with a refresh timer. This PR also has a slight refactor that gets rid of the `aeris` "namespace" in `utils` and just calls the layers what they are (FloodAlertsLayer, AnimatedWeatherLayer) since their source is not really important.

It will also need to have a query method written that will call the Aeris API, but this is hard to do without something to develop against.