### PR TITLE
define process.env.NODE_ENV == 'production' for app code so redux runs

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -20,6 +20,9 @@ const plugins = []
 if (isProd) {
   plugins.push(new ExtractTextPlugin('styles.css'))
   plugins.push(new webpack.optimize.UglifyJsPlugin())
+  plugins.push(new webpack.DefinePlugin({
+    'process.env.NODE_ENV': '"production"'
+  }))
 }
 
 export default {


### PR DESCRIPTION
 so redux runs the through the production code paths (which is faster)