### PR TITLE
clickable weather alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-sass": "^3.3.3",
     "nodemon": "^1.4.1",
     "object-assign": "^4.0.1",
+    "object-hash": "^1.1.2",
     "ramda": "^0.19.1",
     "raw-loader": "^0.5.1",
     "react": "^0.14.7",

--- a/src/actions/index.es
+++ b/src/actions/index.es
@@ -24,6 +24,8 @@ export const setBaseLayer = (id) => {
   }
 }
 
+export const setPopup = createAction(types.SET_POPUP, data => data)
+
 export const setFeatureLayer = (id) => {
   return (dispatch) => {
     dispatch(setPopup())
@@ -34,5 +36,3 @@ export const setFeatureLayer = (id) => {
     })
   }
 }
-
-export const setPopup = createAction(types.SET_POPUP, data => data)

--- a/src/components/FloodAlertsPopup.jsx
+++ b/src/components/FloodAlertsPopup.jsx
@@ -23,7 +23,7 @@ export default class FloodAlertsPopup extends Component {
     const { response } = this.props
     return (
       <div>
-        <PopupTitle icon={icon} title="Flood Alert Information" />
+        <PopupTitle icon={icon} title="Weather Alert Information" />
         <PopupContent>
           {response.map(({ details }) => {
             const id = hash(details, { algorithm: 'md5', encoding: 'base64' })

--- a/src/components/FloodAlertsPopup.jsx
+++ b/src/components/FloodAlertsPopup.jsx
@@ -1,0 +1,45 @@
+import React, { Component, PropTypes } from 'react'
+import hash from 'object-hash'
+
+import PopupTitle from './PopupTitle'
+import PopupContent from './PopupContent'
+import PopupHeader from './PopupHeader'
+import PopupText from './PopupText'
+
+const icon = require('../images/flood_alert_white.png')
+
+export default class FloodAlertsPopup extends Component {
+  static propTypes = {
+    response: PropTypes.array,
+    updatePopup: PropTypes.func,
+  }
+
+  componentDidUpdate() {
+    const { updatePopup } = this.props
+    updatePopup()
+  }
+
+  render() {
+    const { response } = this.props
+    return (
+      <div>
+        <PopupTitle icon={icon} title="Flood Alert Information" />
+        <PopupContent>
+          {response.map(({ details }) => {
+            const id = hash(details, { algorithm: 'md5', encoding: 'base64' })
+            return (
+              <div key={ id }>
+                <PopupHeader>
+                  { details.name }
+                </PopupHeader>
+                <PopupText>
+                  { details.body }
+                </PopupText>
+              </div>
+            )
+          })}
+        </PopupContent>
+      </div>
+    )
+  }
+}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -17,6 +17,7 @@ export default class Map extends Component {
       active: PropTypes.string
     }),
     onLayerStatusChange: PropTypes.func.isRequired,
+    onClickAlerts: PropTypes.func.isRequired,
     onClickUTFGrid: PropTypes.func.isRequired,
     onMouseoutUTFGrid: PropTypes.func.isRequired,
     onMouseoverUTFGrid: PropTypes.func.isRequired,
@@ -117,6 +118,7 @@ export default class Map extends Component {
       map,
       handlers: {
         layerStatusChange: this.props.onLayerStatusChange,
+        onClickAlerts: this.props.onClickAlerts,
         onClickUTFGrid: this.props.onClickUTFGrid,
         onMouseoutUTFGrid: this.props.onMouseoutUTFGrid,
         onMouseoverUTFGrid: this.props.onMouseoverUTFGrid,

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import R from 'ramda'
 import React, { Component, PropTypes } from 'react'
 
+import FloodAlertsPopup from './FloodAlertsPopup'
 import FloodGaugePopup from './FloodGaugePopup'
 import LakeConditionsPopup from './LakeConditionsPopup'
 
@@ -44,7 +45,7 @@ export default class Popup extends Component {
       this.updatePopupSize()
     }
 
-    if (prevProps.browser.width !== this.props.browser.width) {
+    if (prevProps.browser.width !== this.props.browser.width || prevProps.browser.height !== this.props.browser.height) {
       this.updatePopupSize()
     }
 
@@ -74,6 +75,10 @@ export default class Popup extends Component {
         return (
           <LakeConditionsPopup {...data} popupWidth={popupWidth} updatePopup={() => {this.leafletPopup.update()}} />
         )
+      case 'flood-alerts':
+        return (
+          <FloodAlertsPopup {...data} popupWidth={popupWidth} updatePopup={() => {this.updatePopupSize()}} />
+        )
       default:
         return null
     }
@@ -84,6 +89,7 @@ export default class Popup extends Component {
     return {
       maxWidth: leafletMap ? leafletMap.getSize().x * 0.9 : 500,
       minWidth: leafletMap ? Math.min(leafletMap.getSize().x * 0.5, 599) : 270,
+      maxHeight: leafletMap ? leafletMap.getSize().y * 0.9 : 500,
     }
   }
 

--- a/src/components/PopupText.jsx
+++ b/src/components/PopupText.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 
 
-export default class PopupContent extends Component {
+export default class PopupText extends Component {
   render() {
     return (
-      <div className="popup__content">
+      <div className="info__text">
         { this.props.children }
       </div>
     )

--- a/src/containers/MapContainer.jsx
+++ b/src/containers/MapContainer.jsx
@@ -12,26 +12,21 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = (dispatch) => {
+  function clickHandler(id, data) {
+    const payload = {}
+    if (data.data) {
+      payload.id = id
+      payload.data = data
+    }
+    dispatch(actions.setPopup(payload))
+  }
+
   return {
     onLayerStatusChange: (id, status) => {
       dispatch(actions.layerStatusChange(id, status))
     },
-    onClickAlerts: (id, data) => {
-      const payload = {}
-      if (data.data) {
-        payload.id = id
-        payload.data = data
-      }
-      dispatch(actions.setPopup(payload))
-    },
-    onClickUTFGrid: (id, data) => {
-      const payload = {}
-      if (data.data) {
-        payload.id = id
-        payload.data = data
-      }
-      dispatch(actions.setPopup(payload))
-    },
+    onClickAlerts: clickHandler,
+    onClickUTFGrid: clickHandler,
     onMouseoutUTFGrid: () => {
       dispatch(actions.hoverOverMapClickable())
     },

--- a/src/containers/MapContainer.jsx
+++ b/src/containers/MapContainer.jsx
@@ -16,6 +16,14 @@ const mapDispatchToProps = (dispatch) => {
     onLayerStatusChange: (id, status) => {
       dispatch(actions.layerStatusChange(id, status))
     },
+    onClickAlerts: (id, data) => {
+      const payload = {}
+      if (data.data) {
+        payload.id = id
+        payload.data = data
+      }
+      dispatch(actions.setPopup(payload))
+    },
     onClickUTFGrid: (id, data) => {
       const payload = {}
       if (data.data) {

--- a/src/reducers/featureLayers.es
+++ b/src/reducers/featureLayers.es
@@ -62,7 +62,7 @@ const initialState = {
       'icon': floodAlertIcon,
       'type': 'aeris-alerts',
       'options': {
-        'code': 'alerts-flood',
+        'code': 'alerts',
         'refreshTimeMs': 300000, // 5 minutes
         'opacity': 0.7
       },

--- a/src/reducers/featureLayers.es
+++ b/src/reducers/featureLayers.es
@@ -58,7 +58,7 @@ const initialState = {
     },
     {
       'id': 'flood-alerts',
-      'text': 'Flood Alerts',
+      'text': 'Weather Alerts',
       'icon': floodAlertIcon,
       'type': 'aeris-alerts',
       'options': {

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -248,12 +248,20 @@ body {
 .info__name {
   font-weight: 600;
   font-size: 1.5em;
-  margin: 4px 18px 4px 18px;
+  margin: 4px 18px 0px 18px;
+}
+
+.info__text {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 1em;
+  margin: 4px 18px 0px 18px;
+  padding-bottom: 20px;
 }
 
 .info__img {
   img {
-    padding: 0 30 0 30;
+    padding: 4px 30px 0px 30px;
   }
 }
 

--- a/src/util/AerisAlertsLayer.es
+++ b/src/util/AerisAlertsLayer.es
@@ -6,20 +6,21 @@ import AerisTileLayer from './AerisTileLayer'
 
 
 function getAdvisoryInfo({latitude, longitude}) {
+  const queryURL = `https://api.aerisapi.com/advisories/closest`
+  const queryParams = {
+    client_id: keys.aerisApiId,
+    client_secret: keys.aerisApiSecret,
+    p: `${latitude},${longitude}`,
+    radius: '25mi',
+    filter: 'flood',
+    query: 'sigp:1:3:5:9:7:11',
+    active: '1',
+  }
 
-  return axios.get(`https://${account}.cartodb.com/api/v1/map/`, mapConfig)
-    .then(({data}) => {
-      const layerid = data.layergroupid
-      const urls = {
-        tilesUrl: `https://${account}.cartodb.com/api/v1/map/${layerid}/{z}/{x}/{y}.png`
-      }
-      if (options.interactivity) {
-        urls.gridsUrl = `https://${account}.cartodb.com/api/v1/map/${layerid}/0/{z}/{x}/{y}.grid.json`
-      }
-      return urls
+  return axios.get(queryURL, { params: queryParams })
+    .then(({ data }) => {
+      return data
     })
-
-
 }
 
 //TODO: advisory map layers requires an Aeris subscription - they are not available under the development plan
@@ -28,11 +29,20 @@ export default class AerisAlertsLayer extends AerisTileLayer {
     super({domain: 'maps.aerisapi.com', ...options})
 
     this.map.on('click', (event) => {
-      if(this.map.hasLayer(this.layer)) {
-        const data = {
-          latlng: event.latlng,
-        }
-        this.handlers.onClickAlerts(this.id, event)
+      if (this.map.hasLayer(this.layer)) {
+        const latlng = event.latlng
+
+        getAdvisoryInfo({latitude: latlng.lat, longitude: latlng.lng})
+          .then((advisoryData) => {
+            let alertData = {}
+            if (advisoryData.response.length) {
+              alertData = {
+                data: advisoryData,
+                latlng: latlng,
+              }
+            }
+            this.handlers.onClickAlerts(this.id, alertData)
+          })
       }
     })
   }

--- a/src/util/AerisAlertsLayer.es
+++ b/src/util/AerisAlertsLayer.es
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import L from 'leaflet'
+import R from 'ramda'
 
 import keys from '../keys'
 import AerisTileLayer from './AerisTileLayer'
@@ -11,14 +11,16 @@ function getAdvisoryInfo({latitude, longitude}) {
     client_id: keys.aerisApiId,
     client_secret: keys.aerisApiSecret,
     p: `${latitude},${longitude}`,
-    radius: '25mi',
-    filter: 'flood',
-    query: 'sigp:1:3:5:9:7:11',
-    active: '1',
+    limit: 100,
+    active: 1,
   }
 
   return axios.get(queryURL, { params: queryParams })
     .then(({ data }) => {
+      const uniqueResponses = R.uniqBy((response) => {
+        return R.pick(['name', 'body'], response.details)
+      }, data.response)
+      data.response = uniqueResponses
       return data
     })
 }

--- a/src/util/AerisAlertsLayer.es
+++ b/src/util/AerisAlertsLayer.es
@@ -1,12 +1,39 @@
+import axios from 'axios'
 import L from 'leaflet'
 
 import keys from '../keys'
 import AerisTileLayer from './AerisTileLayer'
 
 
+function getAdvisoryInfo({latitude, longitude}) {
+
+  return axios.get(`https://${account}.cartodb.com/api/v1/map/`, mapConfig)
+    .then(({data}) => {
+      const layerid = data.layergroupid
+      const urls = {
+        tilesUrl: `https://${account}.cartodb.com/api/v1/map/${layerid}/{z}/{x}/{y}.png`
+      }
+      if (options.interactivity) {
+        urls.gridsUrl = `https://${account}.cartodb.com/api/v1/map/${layerid}/0/{z}/{x}/{y}.grid.json`
+      }
+      return urls
+    })
+
+
+}
+
 //TODO: advisory map layers requires an Aeris subscription - they are not available under the development plan
 export default class AerisAlertsLayer extends AerisTileLayer {
   constructor(options) {
     super({domain: 'maps.aerisapi.com', ...options})
+
+    this.map.on('click', (event) => {
+      if(this.map.hasLayer(this.layer)) {
+        const data = {
+          latlng: event.latlng,
+        }
+        this.handlers.onClickAlerts(this.id, event)
+      }
+    })
   }
 }

--- a/src/util/AerisAlertsLayer.es
+++ b/src/util/AerisAlertsLayer.es
@@ -11,8 +11,10 @@ function getAdvisoryInfo({latitude, longitude}) {
     client_id: keys.aerisApiId,
     client_secret: keys.aerisApiSecret,
     p: `${latitude},${longitude}`,
+    radius: '20mi',
     limit: 100,
     active: 1,
+    sort: 'sigp',
   }
 
   return axios.get(queryURL, { params: queryParams })


### PR DESCRIPTION
It's working as well as I'll be able to get it for now.

The Aeris alerts and advisories service has some shortcomings which make this less than :100: :
- doesn't currently allow a way to definitively request info for advisories at a given point - this is how point + radius queries should work in theory but they miss pretty often, esp. with arbitrary polygons (not county-wide) and that's what flood warnings often are :(
- because of this, we have to default to showing more flood info than we care to - sometimes when you click near an alert poly but not quite on one, you still get a popup
- had to hack around the fact that it returns duplicate warning info sometimes. If an alert is issues for multiple counties, we get multiple copies of it. kinda dumb.
- does not include the warning ID, so we have no way of linking back to the official NWS site for the warning
- the 'flood' subset doesn't do a good job of representing all the things we want to show - it doesn't include sever storm warnings, for example, nor does it include coastal floods. So we're just using the "every possible alert" layer / service for now

We should follow up with Aeris and ask them what's up / point out the issues when we have some spare time.

If this is considered too broken, we could resort to rendering and updating our own layer but that's going to take some effort.