### PR TITLE
stop "npm install" failing due to pinned version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "webpack-dev-server": "^1.14.1"
   },
   "devDependencies": {
-    "react-addons-test-utils": "^15.0.1"
+    "react-addons-test-utils": "^0.14.8"
   }
 }


### PR DESCRIPTION
Following the README as written, `npm install` installs devDependencies, including react-addons-test-utils pinned to react 15.x. This causes react to `not satisfy its siblings' peerDependencies requirements` and therefore for the `npm install` to fail with `ERR! peerinvalid`:

    npm ERR! peerinvalid The package react@0.14.8 does not satisfy its siblings' peerDependencies requirements!
    npm ERR! peerinvalid Peer react-addons-pure-render-mixin@0.14.8 wants react@^0.14.8
    npm ERR! peerinvalid Peer react-dom@0.14.8 wants react@^0.14.8
    npm ERR! peerinvalid Peer react-ga@1.4.1 wants react@>= 0.14.0
    npm ERR! peerinvalid Peer react-mdl@1.5.4 wants react@0.14.x || ^15.0.0-rc
    npm ERR! peerinvalid Peer react-redux@4.4.5 wants react@^0.14.0 || ^15.0.0-0
    npm ERR! peerinvalid Peer redbox-react@1.2.6 wants react@^0.14.0 || ^15.0.0
    npm ERR! peerinvalid Peer redux-devtools@3.3.1 wants react@^0.14.0 || ^15.0.0-rc.1
    npm ERR! peerinvalid Peer react-addons-test-utils@15.1.0 wants react@^15.1.0

There is also a tangentially related warning

    npm WARN peerDependencies The peer dependency react@^15.1.0 included from react-addons-test-utils will no
    npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
    npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.

We have a choice of possible resolutions, here are 3
1. Change the pinned version of react-addons-test-utils to e.g. ^0.14.8 to remove the conflict
2. Upgrade all the react components to 15.x to match react-addons-test-utils, also doing any necessary testing for such a sweeping change
3. Update the README to specify "npm install --production" in order to avoid the devDependency being installed and sidestep the issue. Lowest effort, but I don't favor it because we still have a broken version of the dev dependency that somehow can't coexist with the application under test.

Here I have PR'd an instance of approach 1 pending any upgrades.

This must not be merged unless it has been verified that it does not break the application. I am currently unable to verify because the app is not yet working for me locally, which is how I came across this issue.