### PR TITLE
correct leaflet map center/zoom on firefox

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -56,9 +56,6 @@ export default class Map extends Component {
         minZoom: 5
       })
 
-      // fit to Texas
-      this.map.fitBounds([[25.8371, -106.6460], [36.5007, -93.5083]])
-
       this.map.zoomControl.setPosition('topright')
       this.map.attributionControl.setPrefix('Data Sourced From')
 
@@ -69,6 +66,8 @@ export default class Map extends Component {
   }
 
   componentWillUpdate(nextProps) {
+    this.map.invalidateSize('false')
+
     // only trigger show() and hide() on feature layers when the set of active
     // layers has changed, or an active layer has had a status change
     const activeFeatureLayerBools = (props) => {


### PR DESCRIPTION
This is for issue #108, where the leaflet slippy map looks all messed up on Firefox (see that issue for details).

I'm troubled by this issue. I'm also not happy with this PR's way of resolving it. I'd only consider merging this PR insofar as working is better than broken, but nothing about it is clear to me.

in Map.jsx - `componentDidMount`, passing `100` instead of `0` (i.e., 100ms instead of 0ms) as the second arg to `setTimeout` seems to mitigate or solve the issue, suggesting some race condition, so this is obviously not a real solution. I don't even like that `setTimeout` is involved at all, and after experimenting I'm not totally certain it's necessary, but I'm not about to remove it because I have no idea what issue initially motivated its use and similar kludges have proliferated in the wider world.

removing the call to `fitBounds` seems to fix the zoom level issue on Firefox, and doesn't affect anything on Chrome, but it still annoys me as a solution because someone thought that call was necessary before and it was working on Chrome before. Again, lacking any statement of intent and  a test suite all I have to go on is manual testing, which is really heuristic.

Since this involves leaflet's sizing it sort of makes sense to issue invalidateSize, sort of.  The fullscreen button code used to call this.map.invalidateSize, removing that code might have resulted in it not being called as intended (I wish the need for it had been commented in, if it was needed before). 
Now I can't cite any specific reason why invalidateSize should be in componentWillUpdate vs. componentDidMount, except that it doesn't work in componentDidMount, and componentWillupdate is later. Bleh.
